### PR TITLE
Added missing header

### DIFF
--- a/shuriken/include/shuriken/common/shurikenstream.h
+++ b/shuriken/include/shuriken/common/shurikenstream.h
@@ -10,6 +10,7 @@
 
 #include <fstream>
 #include <cassert>
+#include <cstdint>
 
 namespace shuriken {
     namespace common {

--- a/shuriken/include/shuriken/parser/Dex/dvm_types.h
+++ b/shuriken/include/shuriken/parser/Dex/dvm_types.h
@@ -9,6 +9,7 @@
 #define SHURIKENLIB_DVM_TYPES_H
 
 #include <iostream>
+#include <cstdint>
 
 namespace shuriken {
     namespace dex {


### PR DESCRIPTION
Following the recommendations from https://gcc.gnu.org/gcc-13/porting_to.html, a missing header has been included fixing the compilation issue.